### PR TITLE
fix: write to temp files to support .pptx and .docx

### DIFF
--- a/pipeline-notebooks/pipeline-general.ipynb
+++ b/pipeline-notebooks/pipeline-general.ipynb
@@ -1,132 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "35227754",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<!-- \n",
-       "If you can see this code, this cell's output is not trusted.\n",
-       "Please execute this cell and save the notebook, or click File -> Trust Notebook\n",
-       "-->\n",
-       "<script>\n",
-       "var shown = true;\n",
-       "\n",
-       "function filter_cells_by_tag(tag) {\n",
-       "    out = Array();\n",
-       "    all_cells = Jupyter.notebook.get_cells()\n",
-       "    for (var i=0; i<all_cells.length; i++) {\n",
-       "        var curr_cell = all_cells[i];\n",
-       "        var tags = curr_cell._metadata.tags;\n",
-       "        if (tags != undefined) {\n",
-       "            for (var j=0; j<tags.length; j++) {\n",
-       "                var curr_tag = tags[j];\n",
-       "                if (curr_tag == tag) {\n",
-       "                    out.push(curr_cell);\n",
-       "                    break;\n",
-       "                }\n",
-       "            }\n",
-       "        }\n",
-       "    }\n",
-       "    return out;\n",
-       "}\n",
-       "\n",
-       "function set_cell_visibility(tag, show, input_only) {\n",
-       "    var cells = Jupyter.notebook.get_cells();\n",
-       "    var marked_cells = filter_cells_by_tag(tag);\n",
-       "    for (var i=0; i<marked_cells.length; i++) {\n",
-       "        var curr_cell = marked_cells[i];\n",
-       "        if (input_only) {\n",
-       "            obj = curr_cell.input\n",
-       "        } else {\n",
-       "            obj = curr_cell.element\n",
-       "        }\n",
-       "        if (show) {\n",
-       "            obj.show();\n",
-       "        } else {\n",
-       "            obj.hide();\n",
-       "        }\n",
-       "    }\n",
-       "}\n",
-       "\n",
-       "function toggle_cell_visibility(tag) {\n",
-       "    set_cell_visibility(tag, shown, false)\n",
-       "    shown = ! shown;\n",
-       "}\n",
-       "\n",
-       "set_cell_visibility('execution_cell', false, true);\n",
-       "</script>\n",
-       "To toggle visibility of explanation cells click <a href=\"javascript:toggle_cell_visibility('explanatory_cell')\">here</a>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%%html\n",
-    "<!-- \n",
-    "If you can see this code, this cell's output is not trusted.\n",
-    "Please execute this cell and save the notebook, or click File -> Trust Notebook\n",
-    "-->\n",
-    "<script>\n",
-    "var shown = true;\n",
-    "\n",
-    "function filter_cells_by_tag(tag) {\n",
-    "    out = Array();\n",
-    "    all_cells = Jupyter.notebook.get_cells()\n",
-    "    for (var i=0; i<all_cells.length; i++) {\n",
-    "        var curr_cell = all_cells[i];\n",
-    "        var tags = curr_cell._metadata.tags;\n",
-    "        if (tags != undefined) {\n",
-    "            for (var j=0; j<tags.length; j++) {\n",
-    "                var curr_tag = tags[j];\n",
-    "                if (curr_tag == tag) {\n",
-    "                    out.push(curr_cell);\n",
-    "                    break;\n",
-    "                }\n",
-    "            }\n",
-    "        }\n",
-    "    }\n",
-    "    return out;\n",
-    "}\n",
-    "\n",
-    "function set_cell_visibility(tag, show, input_only) {\n",
-    "    var cells = Jupyter.notebook.get_cells();\n",
-    "    var marked_cells = filter_cells_by_tag(tag);\n",
-    "    for (var i=0; i<marked_cells.length; i++) {\n",
-    "        var curr_cell = marked_cells[i];\n",
-    "        if (input_only) {\n",
-    "            obj = curr_cell.input\n",
-    "        } else {\n",
-    "            obj = curr_cell.element\n",
-    "        }\n",
-    "        if (show) {\n",
-    "            obj.show();\n",
-    "        } else {\n",
-    "            obj.hide();\n",
-    "        }\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "function toggle_cell_visibility(tag) {\n",
-    "    set_cell_visibility(tag, shown, false)\n",
-    "    shown = ! shown;\n",
-    "}\n",
-    "\n",
-    "set_cell_visibility('execution_cell', false, true);\n",
-    "</script>\n",
-    "To toggle visibility of explanation cells click <a href=\"javascript:toggle_cell_visibility('explanatory_cell')\">here</a>\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "e908195c",
    "metadata": {},
@@ -161,7 +35,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "01a62fe4",
    "metadata": {},
@@ -345,7 +218,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5c9e618c",
    "metadata": {},
@@ -630,7 +502,8 @@
    "source": [
     "# pipeline-api\n",
     "from unstructured.partition.auto import partition\n",
-    "from unstructured.staging.base import convert_to_isd"
+    "from unstructured.staging.base import convert_to_isd\n",
+    "import tempfile"
    ]
   },
   {
@@ -642,9 +515,17 @@
    "source": [
     "# pipeline-api\n",
     "def pipeline_api(file, response_type=\"application/json\"):\n",
+    "    # NOTE(robinson) - This is a hacky solution due to \n",
+    "    # limitations in the SpooledTemporaryFile wrapper. \n",
+    "    # Specifically, it does't have a `seekable` attribute,\n",
+    "    # which is required for .pptx and .docx. See below\n",
+    "    # the link below\n",
+    "    # ref: https://stackoverflow.com/questions/47160211\n",
+    "    # /why-doesnt-tempfile-spooledtemporaryfile-implement-readable-writable-seekable\n",
+    "    with tempfile.NamedTemporaryFile() as temp_file:\n",
+    "        temp_file.write(file.read())\n",
+    "        elements = partition(filename=temp_file.name)\n",
     "    \n",
-    "    elements = partition(file=file)    \n",
-    "\n",
     "    return convert_to_isd(elements)"
    ]
   },
@@ -796,9 +677,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Summary

Closes #41 and writes the `SpooledTemporaryFile` file-like object to a temporary file so that we can process `.pptx` and `.docx` files. This is an issue with the `SpooledTemporaryFile` wrapper itself. Per [this post](https://stackoverflow.com/questions/47160211/why-doesnt-tempfile-spooledtemporaryfile-implement-readable-writable-seekable), it does not have a `seekable` attribute, which is required to read the file in `python-docx` and `python-pptx`.

Note, this is a bit of a hacky fix and long term it would be better to:
- Fix this in `unstructured-api-tools`
- Limit the temp file behavior to `.pptx` and `.docx`, since it's an unnecessary read/write otherwise.

### Testing

Run `make run-web-app` and then do the following `curl` commands. You should see JSON output, where previously these calls produced an error.

```
curl -X 'POST' \
  'http://localhost:8000/general/v0.0.4/general' \
  -H 'accept: application/json' \
  -H 'Content-Type: multipart/form-data' \
  -F 'files=@fake-power-point.pptx' \
  | jq -C . | less -R
```

```
curl -X 'POST' \
  'http://localhost:8000/general/v0.0.4/general' \
  -H 'accept: application/json' \
  -H 'Content-Type: multipart/form-data' \
  -F 'files=@fake.docx' \
```